### PR TITLE
[PATCH]: adjust CMake options for Xcode 14.2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,19 @@
 commit_hash.txt
 prerelease.txt
 
+
+.DS_Store
+node_modules
+*.dylib
+*.dll
+*.slo
+*.lo
+*.o
+*.obj
+solidity_*
+*.tar.gz
+*.zip
+
 # Compiled Object files
 *.slo
 *.lo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
 set(PROJECT_VERSION "0.5.14")
+# OSX target needed in order to support std::visit
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
 project(solidity VERSION ${PROJECT_VERSION} LANGUAGES C CXX)
 
 include(TestBigEndian)

--- a/__build_arm64__/1_fix_.diff
+++ b/__build_arm64__/1_fix_.diff
@@ -1,0 +1,82 @@
+--- a/libsolidity/analysis/GlobalContext.cpp
++++ b/libsolidity/analysis/GlobalContext.cpp
+@@ -91,7 +91,7 @@ vector<Declaration const*> GlobalContext::declarations() const
+ {
+ 	vector<Declaration const*> declarations;
+ 	declarations.reserve(m_magicVariables.size());
+-	for (ASTPointer<Declaration const> const& variable: m_magicVariables)
++	for (ASTPointer<Declaration const> const variable: m_magicVariables)
+ 		declarations.push_back(variable.get());
+ 	return declarations;
+ }
+diff --git a/libsolidity/codegen/ContractCompiler.cpp b/libsolidity/codegen/ContractCompiler.cpp
+index a9c3990f8d2e..d4e2c66b786f 100644
+--- a/libsolidity/codegen/ContractCompiler.cpp
++++ b/libsolidity/codegen/ContractCompiler.cpp
+@@ -512,13 +512,13 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
+ 	if (!_function.isConstructor())
+ 		// adding 1 for return address.
+ 		m_context.adjustStackOffset(parametersSize + 1);
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters())
++	for (ASTPointer<VariableDeclaration const> const variable: _function.parameters())
+ 	{
+ 		m_context.addVariable(*variable, parametersSize);
+ 		parametersSize -= variable->annotation().type->sizeOnStack();
+ 	}
+ 
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.returnParameters())
++	for (ASTPointer<VariableDeclaration const> const variable: _function.returnParameters())
+ 		appendStackVariableInitialisation(*variable);
+ 
+ 	if (_function.isConstructor())
+@@ -571,7 +571,7 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
+ 		if (stackLayout[i] != i)
+ 			solAssert(false, "Invalid stack layout on cleanup.");
+ 
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters() + _function.returnParameters())
++	for (ASTPointer<VariableDeclaration const> const variable: _function.parameters() + _function.returnParameters())
+ 		m_context.removeVariable(*variable);
+ 
+ 	m_context.adjustStackOffset(-(int)c_returnValuesSize);
+diff --git a/libyul/optimiser/NameCollector.cpp b/libyul/optimiser/NameCollector.cpp
+index 04631a86ae73..15d74b59be4b 100644
+--- a/libyul/optimiser/NameCollector.cpp
++++ b/libyul/optimiser/NameCollector.cpp
+@@ -35,9 +35,9 @@ void NameCollector::operator()(VariableDeclaration const& _varDecl)
+ void NameCollector::operator ()(FunctionDefinition const& _funDef)
+ {
+ 	m_names.emplace(_funDef.name);
+-	for (auto const arg: _funDef.parameters)
++	for (auto const& arg: _funDef.parameters)
+ 		m_names.emplace(arg.name);
+-	for (auto const ret: _funDef.returnVariables)
++	for (auto const& ret: _funDef.returnVariables)
+ 		m_names.emplace(ret.name);
+ 	ASTWalker::operator ()(_funDef);
+ }
+diff --git a/test/libsolidity/SolidityTypes.cpp b/test/libsolidity/SolidityTypes.cpp
+index dc3b18c88ab6..8e80230bf462 100644
+--- a/test/libsolidity/SolidityTypes.cpp
++++ b/test/libsolidity/SolidityTypes.cpp
+@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(helper_bool_result)
+ 
+ 	BoolResult r7{true};
+ 	// Attention: this will implicitly convert to bool.
+-	BoolResult r8{"true"};
++	BoolResult r8{true};
+ 	r7.merge(r8, logical_and<bool>());
+ 	BOOST_REQUIRE_EQUAL(r7.get(), true);
+ 	BOOST_REQUIRE_EQUAL(r7.message(), "");
+diff --git a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+index 44e533f5040c..f9b90609d0c1 100644
+--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
++++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+@@ -337,6 +337,8 @@ u256 EVMInstructionInterpreter::eval(
+ 		throw ExplicitlyTerminated();
+ 	case Instruction::POP:
+ 		break;
++    case Instruction::BLOBHASH:
++        return 0;
+ 	// --------------- invalid in strict assembly ---------------
+ 	case Instruction::JUMP:
+ 	case Instruction::JUMPI:

--- a/__build_arm64__/2_fix_.diff
+++ b/__build_arm64__/2_fix_.diff
@@ -1,0 +1,43 @@
+--- a/libevmasm/BlockDeduplicator.h
++++ b/libevmasm/BlockDeduplicator.h
+@@ -65,7 +65,7 @@ class BlockDeduplicator
+ 	/// Iterator that skips tags and skips to the end if (all branches of) the control
+ 	/// flow does not continue to the next instruction.
+ 	/// If the arguments are supplied to the constructor, replaces items on the fly.
+-	struct BlockIterator: std::iterator<std::forward_iterator_tag, AssemblyItem const>
++	struct BlockIterator //: std::iterator<std::forward_iterator_tag, AssemblyItem const>
+ 	{
+ 	public:
+ 		BlockIterator(
+@@ -83,6 +83,12 @@ class BlockDeduplicator
+ 		AssemblyItems::const_iterator end;
+ 		AssemblyItem const* replaceItem;
+ 		AssemblyItem const* replaceWith;
++
++		typedef std::forward_iterator_tag iterator_category;
++		typedef std::ptrdiff_t difference_type;
++		typedef AssemblyItems& reference;
++		typedef AssemblyItems* pointer;
++		typedef AssemblyItem value_type;
+ 	};
+ 
+ 	std::map<u256, u256> m_replacedTags;
+diff --git a/liblll/Parser.cpp b/liblll/Parser.cpp
+index 3b68bc2daea8..e8508f1b4985 100644
+--- a/liblll/Parser.cpp
++++ b/liblll/Parser.cpp
+@@ -67,8 +67,12 @@ void dev::lll::debugOutAST(ostream& _out, sp::utree const& _this)
+ 
+ 		break;
+ 	case sp::utree_type::int_type: _out << _this.get<int>(); break;
+-	case sp::utree_type::string_type: _out << "\"" << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>() << "\""; break;
+-	case sp::utree_type::symbol_type: _out << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>(); break;
++	case sp::utree_type::string_type:
++		_out << "\"";
++		operator<<(_out, _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>()) << "\""; break;
++	case sp::utree_type::symbol_type:
++		operator<<(_out, _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>());
++		break;
+ 	case sp::utree_type::any_type: _out << *_this.get<bigint*>(); break;
+ 	default: _out << "nil";
+ 	}

--- a/__build_arm64__/BUILD
+++ b/__build_arm64__/BUILD
@@ -1,0 +1,1 @@
+make_build.sh

--- a/__build_arm64__/CombinedPatchset.diff
+++ b/__build_arm64__/CombinedPatchset.diff
@@ -1,0 +1,124 @@
+unchanged:
+--- a/libsolidity/analysis/GlobalContext.cpp
++++ b/libsolidity/analysis/GlobalContext.cpp
+@@ -91,7 +91,7 @@ vector<Declaration const*> GlobalContext::declarations() const
+ {
+ 	vector<Declaration const*> declarations;
+ 	declarations.reserve(m_magicVariables.size());
+-	for (ASTPointer<Declaration const> const& variable: m_magicVariables)
++	for (ASTPointer<Declaration const> const variable: m_magicVariables)
+ 		declarations.push_back(variable.get());
+ 	return declarations;
+ }
+unchanged:
+--- a/libsolidity/codegen/ContractCompiler.cpp
++++ b/libsolidity/codegen/ContractCompiler.cpp
+@@ -512,13 +512,13 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
+ 	if (!_function.isConstructor())
+ 		// adding 1 for return address.
+ 		m_context.adjustStackOffset(parametersSize + 1);
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters())
++	for (ASTPointer<VariableDeclaration const> const variable: _function.parameters())
+ 	{
+ 		m_context.addVariable(*variable, parametersSize);
+ 		parametersSize -= variable->annotation().type->sizeOnStack();
+ 	}
+ 
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.returnParameters())
++	for (ASTPointer<VariableDeclaration const> const variable: _function.returnParameters())
+ 		appendStackVariableInitialisation(*variable);
+ 
+ 	if (_function.isConstructor())
+@@ -571,7 +571,7 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
+ 		if (stackLayout[i] != i)
+ 			solAssert(false, "Invalid stack layout on cleanup.");
+ 
+-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters() + _function.returnParameters())
++	for (ASTPointer<VariableDeclaration const> const variable: _function.parameters() + _function.returnParameters())
+ 		m_context.removeVariable(*variable);
+ 
+ 	m_context.adjustStackOffset(-(int)c_returnValuesSize);
+unchanged:
+--- a/libyul/optimiser/NameCollector.cpp
++++ b/libyul/optimiser/NameCollector.cpp
+@@ -35,9 +35,9 @@ void NameCollector::operator()(VariableDeclaration const& _varDecl)
+ void NameCollector::operator ()(FunctionDefinition const& _funDef)
+ {
+ 	m_names.emplace(_funDef.name);
+-	for (auto const arg: _funDef.parameters)
++	for (auto const& arg: _funDef.parameters)
+ 		m_names.emplace(arg.name);
+-	for (auto const ret: _funDef.returnVariables)
++	for (auto const& ret: _funDef.returnVariables)
+ 		m_names.emplace(ret.name);
+ 	ASTWalker::operator ()(_funDef);
+ }
+unchanged:
+--- a/test/libsolidity/SolidityTypes.cpp
++++ b/test/libsolidity/SolidityTypes.cpp
+@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(helper_bool_result)
+ 
+ 	BoolResult r7{true};
+ 	// Attention: this will implicitly convert to bool.
+-	BoolResult r8{"true"};
++	BoolResult r8{true};
+ 	r7.merge(r8, logical_and<bool>());
+ 	BOOST_REQUIRE_EQUAL(r7.get(), true);
+ 	BOOST_REQUIRE_EQUAL(r7.message(), "");
+unchanged:
+--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
++++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+@@ -337,6 +337,8 @@ u256 EVMInstructionInterpreter::eval(
+ 		throw ExplicitlyTerminated();
+ 	case Instruction::POP:
+ 		break;
++    case Instruction::BLOBHASH:
++        return 0;
+ 	// --------------- invalid in strict assembly ---------------
+ 	case Instruction::JUMP:
+ 	case Instruction::JUMPI:
+only in patch2:
+unchanged:
+--- a/libevmasm/BlockDeduplicator.h
++++ b/libevmasm/BlockDeduplicator.h
+@@ -65,7 +65,7 @@ class BlockDeduplicator
+ 	/// Iterator that skips tags and skips to the end if (all branches of) the control
+ 	/// flow does not continue to the next instruction.
+ 	/// If the arguments are supplied to the constructor, replaces items on the fly.
+-	struct BlockIterator: std::iterator<std::forward_iterator_tag, AssemblyItem const>
++	struct BlockIterator //: std::iterator<std::forward_iterator_tag, AssemblyItem const>
+ 	{
+ 	public:
+ 		BlockIterator(
+@@ -83,6 +83,12 @@ class BlockDeduplicator
+ 		AssemblyItems::const_iterator end;
+ 		AssemblyItem const* replaceItem;
+ 		AssemblyItem const* replaceWith;
++
++		typedef std::forward_iterator_tag iterator_category;
++		typedef std::ptrdiff_t difference_type;
++		typedef AssemblyItems& reference;
++		typedef AssemblyItems* pointer;
++		typedef AssemblyItem value_type;
+ 	};
+ 
+ 	std::map<u256, u256> m_replacedTags;
+only in patch2:
+unchanged:
+--- a/liblll/Parser.cpp
++++ b/liblll/Parser.cpp
+@@ -67,8 +67,12 @@ void dev::lll::debugOutAST(ostream& _out, sp::utree const& _this)
+ 
+ 		break;
+ 	case sp::utree_type::int_type: _out << _this.get<int>(); break;
+-	case sp::utree_type::string_type: _out << "\"" << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>() << "\""; break;
+-	case sp::utree_type::symbol_type: _out << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>(); break;
++	case sp::utree_type::string_type:
++		_out << "\"";
++		operator<<(_out, _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>()) << "\""; break;
++	case sp::utree_type::symbol_type:
++		operator<<(_out, _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>());
++		break;
+ 	case sp::utree_type::any_type: _out << *_this.get<bigint*>(); break;
+ 	default: _out << "nil";
+ 	}

--- a/__build_arm64__/boost_setup.sh
+++ b/__build_arm64__/boost_setup.sh
@@ -1,0 +1,11 @@
+wget -q 'https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2' -O boost.tar.bz2; \
+    test "$(sha256sum boost.tar.bz2)" = "4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402  boost.tar.bz2"; \
+    tar -xf boost.tar.bz2; \
+    rm boost.tar.bz2; \
+    cd boost_1_73_0; \
+    CXXFLAGS="-stdlib=libc++ -pthread" LDFLAGS="-stdlib=libc++" ./bootstrap.sh --with-toolset=clang --prefix=/usr; \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++ -pthread" linkflags="-stdlib=libc++ -pthread" headers; \
+    ./b2 toolset=clang cxxflags="-stdlib=libc++ -pthread" linkflags="-stdlib=libc++ -pthread" \
+        link=static variant=release runtime-link=static \
+        system filesystem unit_test_framework program_options \
+        install -j $(($(nproc)/2)); 

--- a/__build_arm64__/debug_build.sh
+++ b/__build_arm64__/debug_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "LLVM Debug Build starting...."
+
+rm -rf build
+mkdir -p build && cd build/
+
+cmake .. -DCMAKE_BUILD_TYPE=Release -DLLL=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+make lllc

--- a/__build_arm64__/env.sh
+++ b/__build_arm64__/env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+dir=`dirname "$0"`
+progname=`basename "$0"`
+
+host=${progname%-cmake}
+if test "$host" = "osxcross" ; then
+   echo "Do not invoke this script directly."
+   exit 1
+fi
+
+eval "`$dir/$host-osxcross-conf`"
+export OSXCROSS_HOST="$host"

--- a/__build_arm64__/make_build.sh
+++ b/__build_arm64__/make_build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+
+echo "WARNING: acOS requirements assumed to be available and installed already..."
+
+sleep 1
+
+# CMakeLists.txt:~L12-L13
+# set(PROJECT_VERSION 0.0.0)
+
+echo "PROJECT_VERSION: 0.5.14"
+# -DLLLC_LINK_STATIC=ON
+
+export LDFLAGS="-L/usr/local/opt/llvm/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
+mkdir -p build/ && cd build/ || exit 127
+
+(cmake .. -DCMAKE_BUILD_TYPE=Release -DLLL=1 -DUSE_Z3=OFF -DCMAKE_OSX_ARCHITECTURES='arm64' --fresh && make lllc) || exit 127

--- a/__build_arm64__/make_tarball.sh
+++ b/__build_arm64__/make_tarball.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+gtar --sort=name \
+      --owner=0 --group=0 --numeric-owner \
+      --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime \
+      -cf lllc-arm64.tar.gz build/lllc

--- a/__build_arm64__/mkbuild.sh
+++ b/__build_arm64__/mkbuild.sh
@@ -1,0 +1,20 @@
+
+
+date -u +"release.%Y.%-m.%-d"
+export CMAKE_BUILD_TYPE=Release
+export MAKEFLAGS=-j10
+echo -n > prerelease.txt
+
+
+echo "SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)" >> $GITHUB_ENV
+echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)" >> $GITHUB_ENV
+echo -n "$GITHUB_COMMIT" > commit_hash.txt
+TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="llc.%cd"
+
+mkdir -p build
+cd build
+echo "Starting source build...."
+
+# -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}"
+
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="$OSXCROSS_TARGET_DIR"/toolchain.cmake 

--- a/__build_arm64__/test_build.sh
+++ b/__build_arm64__/test_build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Clone and Build from retesteth upstream
+
+git clone --depth 1 -b master https://github.com/winsvega/solidity.git lllc/
+cd lllc || exit 127
+(mkdir /build && cd /build || exit 127)
+sleep 1
+(cmake .. -DCMAKE_BUILD_TYPE=Release -DLLL=1 && make lllc) || exit 127

--- a/__build_arm64__/toolchain.cmake
+++ b/__build_arm64__/toolchain.cmake
@@ -1,0 +1,44 @@
+# OSXCross toolchain
+
+macro(osxcross_getconf VAR)
+  if(NOT ${VAR})
+    set(${VAR} "$ENV{${VAR}}")
+    if(${VAR})
+      set(${VAR} "${${VAR}}" CACHE STRING "${VAR}")
+      message(STATUS "Found ${VAR}: ${${VAR}}")
+    else()
+      message(FATAL_ERROR "Cannot determine \"${VAR}\"")
+    endif()
+  endif()
+endmacro()
+
+osxcross_getconf(OSXCROSS_HOST)
+osxcross_getconf(OSXCROSS_TARGET_DIR)
+osxcross_getconf(OSXCROSS_TARGET)
+osxcross_getconf(OSXCROSS_SDK)
+
+set(CMAKE_SYSTEM_NAME "Darwin")
+string(REGEX REPLACE "-.*" "" CMAKE_SYSTEM_PROCESSOR "${OSXCROSS_HOST}")
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang")
+set(CMAKE_CXX_COMPILER "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-clang++")
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH
+  "${OSXCROSS_SDK}"
+  "${OSXCROSS_TARGET_DIR}/macports/pkgs/opt/local")
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(CMAKE_AR "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-ar" CACHE FILEPATH "ar")
+set(CMAKE_RANLIB "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-ranlib" CACHE FILEPATH "ranlib")
+set(CMAKE_INSTALL_NAME_TOOL "${OSXCROSS_TARGET_DIR}/bin/${OSXCROSS_HOST}-install_name_tool" CACHE FILEPATH "install_name_tool")
+
+set(ENV{PKG_CONFIG_LIBDIR} "${OSXCROSS_TARGET_DIR}/macports/pkgs/opt/local/lib/pkgconfig")
+set(ENV{PKG_CONFIG_SYSROOT_DIR} "${OSXCROSS_TARGET_DIR}/macports/pkgs")

--- a/__build_arm64__/z3_setup.sh
+++ b/__build_arm64__/z3_setup.sh
@@ -1,0 +1,9 @@
+git clone --depth 1 -b z3-4.8.10 https://github.com/Z3Prover/z3.git \
+    /usr/src/z3; \
+    cd /usr/src/z3; \
+    mkdir build; \
+    cd build; \
+    LDFLAGS=$CXXFLAGS cmake -DZ3_BUILD_LIBZ3_SHARED=OFF -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_BUILD_TYPE=Release ..; \
+    make libz3 -j; \
+    make install;

--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -34,6 +34,8 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 	add_compile_options(-Wall)
 	add_compile_options(-Wextra)
 	add_compile_options(-Werror)
+	add_compile_options(-Wno-unqualified-std-cast-call)
+	add_compile_options(-Wno-deprecated-declarations)
 
 	# Configuration-specific compiler settings.
 	set(CMAKE_CXX_FLAGS_DEBUG          "-O0 -g3 -DETH_DEBUG")

--- a/libevmasm/BlockDeduplicator.h
+++ b/libevmasm/BlockDeduplicator.h
@@ -65,7 +65,7 @@ private:
 	/// Iterator that skips tags and skips to the end if (all branches of) the control
 	/// flow does not continue to the next instruction.
 	/// If the arguments are supplied to the constructor, replaces items on the fly.
-	struct BlockIterator: std::iterator<std::forward_iterator_tag, AssemblyItem const>
+	struct BlockIterator //: std::iterator<std::forward_iterator_tag, AssemblyItem const>
 	{
 	public:
 		BlockIterator(
@@ -83,6 +83,12 @@ private:
 		AssemblyItems::const_iterator end;
 		AssemblyItem const* replaceItem;
 		AssemblyItem const* replaceWith;
+
+		typedef std::forward_iterator_tag iterator_category;
+		typedef std::ptrdiff_t difference_type;
+		typedef AssemblyItems& reference;
+		typedef AssemblyItems* pointer;
+		typedef AssemblyItem value_type;
 	};
 
 	std::map<u256, u256> m_replacedTags;

--- a/liblll/Parser.cpp
+++ b/liblll/Parser.cpp
@@ -67,8 +67,12 @@ void dev::lll::debugOutAST(ostream& _out, sp::utree const& _this)
 
 		break;
 	case sp::utree_type::int_type: _out << _this.get<int>(); break;
-	case sp::utree_type::string_type: _out << "\"" << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>() << "\""; break;
-	case sp::utree_type::symbol_type: _out << _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>(); break;
+	case sp::utree_type::string_type:
+		_out << "\"";
+		operator<<(_out, _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::string_type>>()) << "\""; break;
+	case sp::utree_type::symbol_type:
+		operator<<(_out, _this.get<sp::basic_string<boost::iterator_range<char const*>, sp::utree_type::symbol_type>>());
+		break;
 	case sp::utree_type::any_type: _out << *_this.get<bigint*>(); break;
 	default: _out << "nil";
 	}

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -91,7 +91,7 @@ vector<Declaration const*> GlobalContext::declarations() const
 {
 	vector<Declaration const*> declarations;
 	declarations.reserve(m_magicVariables.size());
-	for (ASTPointer<Declaration const> const& variable: m_magicVariables)
+	for (ASTPointer<Declaration const> const variable: m_magicVariables)
 		declarations.push_back(variable.get());
 	return declarations;
 }

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -512,13 +512,13 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
 	if (!_function.isConstructor())
 		// adding 1 for return address.
 		m_context.adjustStackOffset(parametersSize + 1);
-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters())
+	for (ASTPointer<VariableDeclaration const> const variable: _function.parameters())
 	{
 		m_context.addVariable(*variable, parametersSize);
 		parametersSize -= variable->annotation().type->sizeOnStack();
 	}
 
-	for (ASTPointer<VariableDeclaration const> const& variable: _function.returnParameters())
+	for (ASTPointer<VariableDeclaration const> const variable: _function.returnParameters())
 		appendStackVariableInitialisation(*variable);
 
 	if (_function.isConstructor())
@@ -571,7 +571,7 @@ bool ContractCompiler::visit(FunctionDefinition const& _function)
 		if (stackLayout[i] != i)
 			solAssert(false, "Invalid stack layout on cleanup.");
 
-	for (ASTPointer<VariableDeclaration const> const& variable: _function.parameters() + _function.returnParameters())
+	for (ASTPointer<VariableDeclaration const> const variable: _function.parameters() + _function.returnParameters())
 		m_context.removeVariable(*variable);
 
 	m_context.adjustStackOffset(-(int)c_returnValuesSize);

--- a/libyul/optimiser/NameCollector.cpp
+++ b/libyul/optimiser/NameCollector.cpp
@@ -35,9 +35,9 @@ void NameCollector::operator()(VariableDeclaration const& _varDecl)
 void NameCollector::operator ()(FunctionDefinition const& _funDef)
 {
 	m_names.emplace(_funDef.name);
-	for (auto const arg: _funDef.parameters)
+	for (auto const& arg: _funDef.parameters)
 		m_names.emplace(arg.name);
-	for (auto const ret: _funDef.returnVariables)
+	for (auto const& ret: _funDef.returnVariables)
 		m_names.emplace(ret.name);
 	ASTWalker::operator ()(_funDef);
 }

--- a/make_build.sh
+++ b/make_build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+
+echo "WARNING: acOS requirements assumed to be available and installed already..."
+
+sleep 1
+
+# CMakeLists.txt:~L12-L13
+# set(PROJECT_VERSION 0.0.0)
+
+echo "PROJECT_VERSION: 0.5.14"
+# -DLLLC_LINK_STATIC=ON
+
+export CONFIG_SHELL=/bin/bash
+export SOLC_TESTS=Off
+export CMAKE_BUILD_TYPE=Release
+export LDFLAGS="-L/usr/local/opt/llvm/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
+mkdir -p build/ && cd build/ || exit 127
+
+(cmake .. -DCMAKE_BUILD_TYPE=Release -DLLL=1 -DUSE_Z3=OFF -DCMAKE_OSX_ARCHITECTURES='arm64' --fresh && make lllc) || exit 127

--- a/make_llvm_debug.sh
+++ b/make_llvm_debug.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+
+echo "WARNING: acOS requirements assumed to be available and installed already..."
+
+sleep 1
+
+# CMakeLists.txt:~L12-L13
+# set(PROJECT_VERSION 0.0.0)
+
+echo "PROJECT_VERSION: 0.5.14"
+# -DLLLC_LINK_STATIC=ON
+
+export CONFIG_SHELL=/bin/bash
+export SOLC_TESTS=Off
+export CMAKE_BUILD_TYPE=Release
+export LDFLAGS="-L/usr/local/opt/llvm/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
+
+
+echo -n > prerelease.txt
+echo -n "$GITHUB_COMMIT" > commit_hash.txt
+
+
+mkdir -p build/ && cd build/ || exit 127
+
+
+(cmake .. -DCMAKE_BUILD_TYPE=Release -DLLL=1 -DUSE_Z3=OFF -DCMAKE_OSX_ARCHITECTURES='arm64' -DCMAKE_EXPORT_COMPILE_COMMANDS=1--fresh && make lllc) || exit 127

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(helper_bool_result)
 
 	BoolResult r7{true};
 	// Attention: this will implicitly convert to bool.
-	BoolResult r8{"true"};
+	BoolResult r8{true};
 	r7.merge(r8, logical_and<bool>());
 	BOOST_REQUIRE_EQUAL(r7.get(), true);
 	BOOST_REQUIRE_EQUAL(r7.message(), "");

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -337,6 +337,8 @@ u256 EVMInstructionInterpreter::eval(
 		throw ExplicitlyTerminated();
 	case Instruction::POP:
 		break;
+    case Instruction::BLOBHASH:
+        return 0;
 	// --------------- invalid in strict assembly ---------------
 	case Instruction::JUMP:
 	case Instruction::JUMPI:


### PR DESCRIPTION
XCode 14.3 adds the ability to `-Werror=unqualified-std-cast-call`  
This warning is due to "unqualified call to 'std::move'"

This is only really helpful for someone using retesteth on Apple Silicon, no need to merge this just opening this just in case there is someone else whom may have such need...  
 

![](https://github.com/winsvega/lllc/assets/32783916/2aeb942f-4190-4dae-b075-58054f638472)